### PR TITLE
Added Additional Git Config Color Options

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -84,6 +84,8 @@ and `color.sh.dirty` git config values:
     $ git config --global color.sh.branch 'yellow reverse'
     $ git config --global color.sh.workdir 'blue bold'
     $ git config --global color.sh.dirty 'red'
+    $ git config --global color.sh.dirty-stash 'red'
+    $ git config --global color.sh.repo-state 'red'
 
 See [colors in git](http://scie.nti.st/2007/5/2/colors-in-git) for information.
 

--- a/git-sh.1.roff
+++ b/git-sh.1.roff
@@ -238,6 +238,8 @@ and \fBcolor.sh.dirty\fR git config values:
 $ git config \-\-global color.sh.branch 'yellow reverse'
 $ git config \-\-global color.sh.workdir 'blue bold'
 $ git config \-\-global color.sh.dirty 'red'
+$ git config \-\-global color.sh.dirty-stash 'red'
+$ git config \-\-global color.sh.repo-state 'red'
 .
 .fi
 .

--- a/git-sh.1.ronn
+++ b/git-sh.1.ronn
@@ -149,6 +149,8 @@ and `color.sh.dirty` git config values:
     $ git config --global color.sh.branch 'yellow reverse'
     $ git config --global color.sh.workdir 'blue bold'
     $ git config --global color.sh.dirty 'red'
+    $ git config --global color.sh.dirty-stash 'red'
+    $ git config --global color.sh.repo-state 'red'
 
 See [colors in git](http://scie.nti.st/2007/5/2/colors-in-git) for information.
 


### PR DESCRIPTION
Howdy,

I added to the docs the additional git color config options I could find in the source (`color.sh.dirty-stash` and `color.sh.repo-state`).

I found `dirty-stash` to work fine; there's no reason why it shouldn't be in the docs. I'm not entirely sure what `repo-state` does; I changed it to blue in my config, but haven't seen anything blue yet. Either way.

I edited the `.roff` file by hand; `make` generated a blank file for me, and it was a fairly simple change.

Cheers,
&nbsp;&nbsp;&nbsp;&nbsp;Slipp
