### PR TITLE
Fix _git_dirty

### DIFF
--- a/git-sh.bash
+++ b/git-sh.bash
@@ -183,7 +183,7 @@ ANSI_RESET="\001$(git config --get-color "" "reset")\002"
 
 # detect whether the tree is in a dirty state. returns
 _git_dirty() {
-	if git status 2>/dev/null | fgrep -q '(working directory clean)'; then
+	if git status 2>/dev/null | fgrep -q 'working directory clean'; then
 		return 0
 	fi
 	local dirty_marker="`git config gitsh.dirty || echo ' *'`"


### PR DESCRIPTION
Since git 1.8.1.1 [1] "git status" on a clean tree displays
"nothing to commit, working directory clean" instead of
"nothing to commit, (working directory clean)"

[1] https://github.com/git/git/commit/50bd8b7eb960ff7a646195e0751b48a0e57e03ad#L0R1050
