### PR TITLE
Suppress dirty marker and errors building PS1 when outside a repo

### DIFF
--- a/git-sh.bash
+++ b/git-sh.bash
@@ -183,6 +183,9 @@ ANSI_RESET="\001$(git config --get-color "" "reset")\002"
 
 # detect whether the tree is in a dirty state.
 _git_dirty() {
+	if ! git rev-parse --verify HEAD >/dev/null 2>&1; then
+		return 0
+	fi
 	local dirty_marker="`git config gitsh.dirty 2>/dev/null || echo ' *'`"
 
 	if ! git diff --quiet 2>/dev/null ; then


### PR DESCRIPTION
Makes moving outside repos much less noisy, which is nice if you're using git-sh as your primary shell (as I am).
