### PR TITLE
Add upstream state to PS1

### DIFF
--- a/git-sh.bash
+++ b/git-sh.bash
@@ -177,7 +177,7 @@ _git_import_aliases () {
 
 # PROMPT =======================================================================
 
-PS1='`_git_headname`!`_git_repo_state``_git_workdir``_git_dirty``_git_dirty_stash`> '
+PS1='`_git_headname``_git_upstream_state`!`_git_repo_state``_git_workdir``_git_dirty``_git_dirty_stash`> '
 
 ANSI_RESET="\001$(git config --get-color "" "reset")\002"
 
@@ -213,6 +213,30 @@ _git_headname() {
 		br=${br#refs/heads/} ||
 		br=`git rev-parse --short HEAD 2>/dev/null`
 	_git_apply_color "$br" "color.sh.branch" "yellow reverse"
+}
+
+# detect the deviation from the upstream branch
+_git_upstream_state() {
+	local p=""
+
+	# Find how many commits we are ahead/behind our upstream
+	local count="$(git rev-list --count --left-right "@{upstream}"...HEAD 2>/dev/null)"
+
+	# calculate the result
+	case "$count" in
+		"") # no upstream
+			p="" ;;
+		"0	0") # equal to upstream
+			p=" u=" ;;
+		"0	"*) # ahead of upstream
+			p=" u+${count#0	}" ;;
+		*"	0") # behind upstream
+			p=" u-${count%	0}" ;;
+		*) # diverged from upstream
+			p=" u+${count#*	}-${count%	*}" ;;
+	esac
+
+	_git_apply_color "$p" "color.sh.upstream-state" "yellow bold"
 }
 
 # detect working directory relative to working tree root


### PR DESCRIPTION
I'm not sure if this is desired but I like to have the upstream state in my prompt (as supported by [git-prompt](https://github.com/git/git/blob/master/contrib/completion/git-prompt.sh#L51)), e.g.:

``` bash
master u=    # same as upstream
master u+3   # ahead of upstream by 3 commits
master u-3   # behind upstream by 3 commits
master u+1-2 # diverged from upstream - I have one commit and they have 2 commits
```

There is also a [less verbose version](https://github.com/git/git/blob/master/contrib/completion/git-prompt.sh#L195) but I didn't add that as I don't use it.
